### PR TITLE
Snapshot coingecko new functions

### DIFF
--- a/src/components/TestPage.tsx
+++ b/src/components/TestPage.tsx
@@ -41,7 +41,7 @@ export const TestPage: NextPage = () => {
       {isFetching ? <div>Refreshing...</div> : null}
       <HStack justify="center">
         <div>
-          {chartdata.map((chart: any, i: any) => (
+          {chartdata.chartdata.map((chart: any, i: any) => (
             <pre key={i}>
               {i} - {chart.round} : {chart.voteEnd}
             </pre>

--- a/src/types/snapshot.raw.ts
+++ b/src/types/snapshot.raw.ts
@@ -1,0 +1,27 @@
+export interface SnapVote {
+  choice: {
+    [key: string]: number; // key is string of pool voteindex + 1
+  }; // number is the weight for this pool
+  vp: number; // voting power
+  voter: string; // evm address
+}
+
+export interface SnapVotePerPool {
+  poolId: string; // string of pool voteindex + 1
+  votes: number; // sum of votes
+  percent: number; // percentage of all votes
+}
+
+export interface SnapSplitVote {
+  poolId: string; // string of pool voteindex + 1
+  votes: number; // votes per user per pool
+  voter: string; // evm address
+}
+
+export interface SnapProposal {
+  start: number; // unix timestamp
+  end: number; // unix timestamp
+  state: string; // "pending"|"active"|"closed"
+  snapshot: string; // ftm block number as string
+  choices: string[]; // list of pools
+}

--- a/src/utils/api/cron.helper.ts
+++ b/src/utils/api/cron.helper.ts
@@ -18,8 +18,10 @@ export async function getData(round: string) {
   const bribedOffers = bribefile.bribedata.map((x) =>
     (x.voteindex + 1).toString()
   );
-  const { end } = await getSnapshotProposal(proposal);
+  const prop = await getSnapshotProposal(proposal);
   const votes = await getSnapshotVotes(proposal);
+  if (!prop) return newData;
+  const { end } = prop;
   const totalVoter = votes.length;
 
   // calculate bribed votes

--- a/src/utils/externalData/coingecko.ts
+++ b/src/utils/externalData/coingecko.ts
@@ -15,3 +15,38 @@ export async function getCoingeckoPrice(token: string, at: number) {
   }
   return answer;
 }
+
+export async function getCoingeckoCurrentPrice(token: string) {
+  const url = `https://api.coingecko.com/api/v3/simple/price?ids=${token}&vs_currencies=usd`;
+  let answer = 0;
+  try {
+    const result = await fetch(url);
+    if (result.ok) {
+      const data = await result.json();
+      answer = Number(data[token].usd);
+    }
+  } catch (error) {
+    return 0;
+  }
+  return answer;
+}
+
+export async function getCoinGeckoHistoryOldMethod(token: string, at: number) {
+  const endTime = new Date(at * 1000)
+    .toLocaleDateString("de-DE")
+    .replace(/\./g, "-");
+  const url = `https://api.coingecko.com/api/v3/coins/${token}/history?date=${endTime}&localization=false`;
+
+  let answer = 0;
+  try {
+    const result = await fetch(url);
+    if (result.ok) {
+      const data = await result.json();
+      answer = Number(data["market_data"]["current_price"].usd);
+      console.log(answer);
+    }
+  } catch (error) {
+    return 0;
+  }
+  return answer;
+}

--- a/src/utils/externalData/snapshot.ts
+++ b/src/utils/externalData/snapshot.ts
@@ -1,54 +1,104 @@
 import { request, gql } from "graphql-request";
-// yarn add graphql graphql-request
+import {
+  SnapProposal,
+  SnapSplitVote,
+  SnapVote,
+  SnapVotePerPool,
+} from "types/snapshot.raw";
 
 const queryUrl = "https://hub.snapshot.org/graphql";
 
-export interface snapVote {
-  choice: {
-    [key: string]: number;
-  };
-  vp: number;
-}
-
-export async function getSnapshotVotes(proposal: string): Promise<snapVote[]> {
-  // Initialize empty array, "first" and "skip", loop
-  let allResults: snapVote[] = [];
-  const first = 1000;
-  let skip = 0;
-  let hasMore = true;
-  // loop until done
-  while (hasMore) {
-    const QUERY = gql`
-      query Votes {
+export async function getSnapshotVotes(proposal: string): Promise<SnapVote[]> {
+  // loop in chunks of 1000
+  try {
+    let allResults: SnapVote[] = [];
+    const first = 1000;
+    let skip = 0;
+    let hasMore = true;
+    while (hasMore) {
+      const QUERY = gql`
+    query Votes {
       votes(
         first: ${first}
         skip: ${skip}
         where: {
           proposal: "${proposal}"
         }
-      ) {
-        choice
-        vp
+        ) {
+          choice
+          vp
+          voter
+        }
       }
+      `;
+      const result = await request(queryUrl, QUERY);
+      allResults = [...allResults, ...result.votes];
+      hasMore = result.votes.length === first;
+      skip += first;
     }
-    `;
-    const result = await request(queryUrl, QUERY);
-    allResults = [...allResults, ...result.votes];
-    hasMore = result.votes.length === first;
-    skip += first;
+    return allResults;
+  } catch (error) {
+    return [] as SnapVote[];
   }
-  return allResults;
 }
 
-export async function getSnapshotProposal(proposal: string) {
+// splits multiple choices to multiple lines single choice
+export async function getSnapshotSplitVotes(
+  proposal: string
+): Promise<SnapSplitVote[]> {
+  const votes = await getSnapshotVotes(proposal);
+  const splitVotes = [] as SnapSplitVote[];
+  votes.forEach(({ choice, vp, voter }) => {
+    const total = Object.values(choice).reduce((a, b) => a + b);
+    for (const [poolId, value] of Object.entries(choice)) {
+      const votes = (vp * value) / total;
+      splitVotes.push({ poolId, votes, voter });
+    }
+  });
+  return splitVotes;
+}
+
+export async function getSnapshotVotesPerPool(
+  proposal: string
+): Promise<SnapVotePerPool[]> {
+  const poolVotes: { [key: string]: number } = {};
+  const votes = await getSnapshotVotes(proposal);
+  votes.forEach(({ choice, vp }) => {
+    const total = Object.values(choice).reduce((a, b) => a + b);
+    for (const [key, value] of Object.entries(choice)) {
+      poolVotes[key] = (poolVotes[key] || 0) + (vp * value) / total;
+    }
+  });
+  const totalVotes = Math.round(
+    Object.values(poolVotes).reduce((a, b) => a + b)
+  );
+  const result = Object.entries(poolVotes).map((x) => {
+    const poolId = x[0];
+    const votes = x[1];
+    const percent = Number(((votes / totalVotes) * 100).toFixed(2));
+    return { poolId, votes, percent };
+  });
+  return result;
+}
+
+export async function getSnapshotProposal(
+  proposal: string
+): Promise<SnapProposal | null> {
   const QUERY = gql`
     query Proposal {
       proposal(id:"${proposal}") {
         start
         end
+        state
+        snapshot
+        choices
       }
     }
   `;
-  const data = await request(queryUrl, QUERY);
-  return data.proposal as { start: number; end: number };
+  try {
+    const data = await request(queryUrl, QUERY);
+    return data.proposal as SnapProposal;
+  } catch (error) {
+    return null;
+  }
 }


### PR DESCRIPTION
Added 2 functions to coingecko: 
- getCoingeckoCurrentPrice fetches current price without timestamp
- getCoingeckoHistoryOldMethod fetches historic price with timestamp using the API endpoint recently used in beetswars V1

Added 2 functions to snapshot:
- getSnapshotSplitVotes returns a plain array with user votes per pool, no more "choices", gives multiple lines on user split votes
- getSnapshotVotesPerPool returns an array with one line per pool, summing up votes and percent of total votes

Added types for return-objects for all snapshot functions

Added error handling for coingecko and snapshot functions, small update in cron.helper.ts to deal with this.