### PR TITLE
Pricefeeds

### DIFF
--- a/src/utils/api/bribeApr.helper.ts
+++ b/src/utils/api/bribeApr.helper.ts
@@ -1,6 +1,6 @@
 import type { EmissionData } from "types/emission.raw";
 import { readOneChartdata } from "utils/database/chartdata.db";
-import { getCoingeckoCurrentPrice } from "utils/externalData/coingecko";
+import { getPrice } from "utils/externalData/pricefeed";
 import { getBlockByTsGraph } from "utils/externalData/theGraph";
 import { getEmissionForBlockspan } from "./emission.helper";
 
@@ -44,7 +44,8 @@ export async function getEmissionForRound(round: number): Promise<EmissionData |
 
   const chartdata = await readOneChartdata(round);
   const beetsPrice = !chartdata
-    ? await getCoingeckoCurrentPrice("beethoven-x")
+    ? // ? await getCoingeckoCurrentPrice("beethoven-x")
+      await getPrice(false, { token: "BEETS", tokenId: 0, coingeckoid: "beethoven-x" })
     : chartdata.priceBeets;
   const usdValue = emission * beetsPrice;
   const voteEmissionPercent = round < 29 ? 0.3 : 0.5;

--- a/src/utils/api/calculateBribe.ts
+++ b/src/utils/api/calculateBribe.ts
@@ -1,7 +1,6 @@
 import type { Bribedata, Tokendata } from "types/bribedata.raw";
 import type { SingleOffer } from "types/bribelist.trpc";
-import { getCoinGeckoHistoryOldMethod } from "utils/externalData/coingecko";
-import { getRpcPrice } from "utils/externalData/liveRpcQueries";
+import { getPrice } from "utils/externalData/pricefeed";
 import { getSnapshotVotesPerPool } from "utils/externalData/snapshot";
 
 export async function calculateSingleOffer(
@@ -50,27 +49,29 @@ export async function calculateSingleOffer(
     let usdValue = 1;
     if (!reward.isfixed) {
       const tokendata = tokenlist.find(x => x.token === reward.token);
-      if (!tokendata) {
-        // console.log(`Tokendata for ${reward.token} not found`);
-        usdValue = 0;
-      } else if (tokendata.lastprice) {
-        // console.log(`lastprice: ${tokendata.lastprice}`);
-        usdValue = tokendata.lastprice;
-      } else if (voteClosed) {
-        if (!tokendata.coingeckoid) {
-          usdValue = 0;
-        } else {
-          usdValue = await getCoinGeckoHistoryOldMethod(tokendata.coingeckoid, voteEnd);
-        }
-        // console.log(`CG price: ${usdValue}`);
-      } else {
-        if (!tokendata.tokenaddress) {
-          usdValue = 0;
-        } else {
-          usdValue = await getRpcPrice(tokendata.tokenaddress);
-          // console.log(`RPC price: ${usdValue}`);
-        }
-      }
+      usdValue = tokendata ? await getPrice(voteClosed, tokendata, voteEnd) : 0;
+      // if (!tokendata) {
+      //   // console.log(`Tokendata for ${reward.token} not found`);
+      //   usdValue = 0;
+      // } else
+      // if (tokendata.lastprice) {
+      //   // console.log(`lastprice: ${tokendata.lastprice}`);
+      //   usdValue = tokendata.lastprice;
+      // } else if (voteClosed) {
+      //   if (!tokendata.coingeckoid) {
+      //     usdValue = 0;
+      //   } else {
+      //     usdValue = await getCoinGeckoHistoryOldMethod(tokendata.coingeckoid, voteEnd);
+      //   }
+      //   // console.log(`CG price: ${usdValue}`);
+      // } else {
+      //   if (!tokendata.tokenaddress) {
+      //     usdValue = 0;
+      //   } else {
+      //     usdValue = await getRpcPrice(tokendata.tokenaddress);
+      //     // console.log(`RPC price: ${usdValue}`);
+      //   }
+      // }
     }
     usdValue *= reward.amount;
 

--- a/src/utils/api/emission.helper.ts
+++ b/src/utils/api/emission.helper.ts
@@ -29,7 +29,7 @@ export async function getEmissionForBlockspan(block1: number, block2: number): P
 export async function checkEmissionChange(lastEmission: Emission): Promise<Emission[]> {
   const stepwidth = 40000; // estimated between 0.5 and 1 days
   let block = lastEmission.block + stepwidth;
-  const oldBeets = lastEmission.beets;
+  let oldBeets = lastEmission.beets;
   const currentBlock = await getBlockByTsGraph(Math.floor(Date.now() / 1000) - 60);
   const data = [] as Emission[];
   while (block < currentBlock + stepwidth) {
@@ -40,6 +40,7 @@ export async function checkEmissionChange(lastEmission: Emission): Promise<Emiss
       const timestamp = await getTsByBlockRPC(newblock);
       data.push({ block: newblock, beets, timestamp });
       block = newblock;
+      oldBeets = beets;
     } else {
       block += stepwidth;
     }

--- a/src/utils/externalData/coingecko.ts
+++ b/src/utils/externalData/coingecko.ts
@@ -34,23 +34,23 @@ export async function getCoingeckoCurrentPrice(token: string): Promise<number> {
   return answer;
 }
 
-export async function getCoinGeckoHistoryOldMethod(
-  token: string,
-  timestamp: number
-): Promise<number> {
-  const endTime = new Date(timestamp * 1000).toLocaleDateString("de-DE").replace(/\./g, "-");
-  const url = `https://api.coingecko.com/api/v3/coins/${token}/history?date=${endTime}&localization=false`;
+// export async function getCoinGeckoHistoryOldMethod(
+//   token: string,
+//   timestamp: number
+// ): Promise<number> {
+//   const endTime = new Date(timestamp * 1000).toLocaleDateString("de-DE").replace(/\./g, "-");
+//   const url = `https://api.coingecko.com/api/v3/coins/${token}/history?date=${endTime}&localization=false`;
 
-  let answer = 0;
-  try {
-    const result = await fetch(url);
-    if (result.ok) {
-      const data = await result.json();
-      answer = Number(data["market_data"]["current_price"].usd);
-    }
-  } catch (error) {
-    console.error("failed getCoingeckoHistoryOldMethod:", error);
-    return 0;
-  }
-  return answer;
-}
+//   let answer = 0;
+//   try {
+//     const result = await fetch(url);
+//     if (result.ok) {
+//       const data = await result.json();
+//       answer = Number(data["market_data"]["current_price"].usd);
+//     }
+//   } catch (error) {
+//     console.error("failed getCoingeckoHistoryOldMethod:", error);
+//     return 0;
+//   }
+//   return answer;
+// }

--- a/src/utils/externalData/pricefeed.ts
+++ b/src/utils/externalData/pricefeed.ts
@@ -1,0 +1,23 @@
+import type { Tokendata } from "types/bribedata.raw";
+import { getTokenPrice } from "./beetsBack";
+import { getCoingeckoCurrentPrice, getCoingeckoPrice } from "./coingecko";
+import { getRpcPrice } from "./liveRpcQueries";
+
+export async function getPrice(history: boolean, token: Tokendata, ts?: number): Promise<number> {
+  if (history) {
+    if (!ts) return 0;
+    if (token.lastprice) return token.lastprice;
+    if (token.coingeckoid) {
+      const price = getCoingeckoPrice(token.coingeckoid, ts);
+      if (price) return price;
+    }
+    if (token.tokenaddress) return getTokenPrice(ts, token.tokenaddress);
+    return 0;
+  }
+  if (token.tokenaddress) {
+    const price = getRpcPrice(token.tokenaddress);
+    if (price) return price;
+  }
+  if (token.coingeckoid) return getCoingeckoCurrentPrice(token.coingeckoid);
+  return 0;
+}


### PR DESCRIPTION
fixes #57 

- create new function "getPrice"
- divert to different external data queries depending on history/live and tokendata. History needs timestamp.

TODO: cleanup after confirm (when next round is finished)