### PR TITLE
calculate voters APR with maBEETS

### DIFF
--- a/src/types/chartdata.raw.ts
+++ b/src/types/chartdata.raw.ts
@@ -25,6 +25,7 @@ export const Chartdata = z.object({
   totalBriber: z.number(),
   priceBeets: z.number(),
   priceFbeets: z.number(),
+  pricePerVp: z.number().optional(),
   bribersRoi: z.number().optional(),
 });
 

--- a/src/utils/api/chartdata.helper.ts
+++ b/src/utils/api/chartdata.helper.ts
@@ -25,9 +25,8 @@ export default async function getEchartData(): Promise<Echarts | null> {
     return new Date(round.voteEnd * 1000).toLocaleDateString("en-US");
   });
   const votingApr = data.map(round => {
-    return parseFloat(
-      ((round.totalBribes / round.priceFbeets / round.bribedVotes) * 26 * 100).toFixed(2)
-    );
+    const priceVP = round.pricePerVp ?? round.priceFbeets;
+    return parseFloat(((round.totalBribes / priceVP / round.bribedVotes) * 26 * 100).toFixed(2));
   });
   const bribersRoi = data.map(round => {
     return !round.bribersRoi ? NaN : Number(round.bribersRoi.toFixed(2));

--- a/src/utils/api/cron.helper.ts
+++ b/src/utils/api/cron.helper.ts
@@ -3,6 +3,7 @@ import { getSnapshotProposal, getSnapshotVotes } from "../externalData/snapshot"
 import { readOneBribefile } from "utils/database/bribefile.db";
 import { getEmissionForRound } from "./bribeApr.helper";
 import { getPrice } from "utils/externalData/pricefeed";
+import { getRelicsFbeetsLocked } from "utils/externalData/theGraph";
 
 export async function getData(round: number) {
   const newData = {} as Chartdata;
@@ -43,6 +44,15 @@ export async function getData(round: number) {
     end
   );
   // const priceFbeets = await getTokenPrice(end, "0xfcef8a994209d6916eb2c86cdd2afd60aa6f54b1");
+
+  let pricePerVp = priceFbeets;
+  if (round >= 32) {
+    const block = parseInt(prop.snapshot);
+    const addresses = votes.map(x => x.voter.toLowerCase());
+    const fbeetsLocked = await getRelicsFbeetsLocked(block, addresses);
+    const result = (priceFbeets * fbeetsLocked) / totalVotes;
+    pricePerVp = result;
+  }
 
   // calculate total bribes
   const bribes = bribedOffers.map(x => {
@@ -102,6 +112,7 @@ export async function getData(round: number) {
   newData.voteEnd = end;
   newData.priceBeets = priceBeets;
   newData.priceFbeets = priceFbeets;
+  newData.pricePerVp = pricePerVp;
   newData.bribersRoi = bribersRoi;
 
   return newData;

--- a/src/utils/externalData/theGraph.ts
+++ b/src/utils/externalData/theGraph.ts
@@ -8,6 +8,14 @@ interface Blocks {
   }[];
 }
 
+interface RelicBalance {
+  address: string;
+  relics: {
+    relicId: number;
+    balance: string;
+  }[];
+}
+
 export async function getBeetsPerBlock(block: number): Promise<number> {
   const queryUrl = "https://api.thegraph.com/subgraphs/name/beethovenxfi/masterchefv2";
   const query = gql`
@@ -58,6 +66,61 @@ export async function getBlockByTsGraph(ts: number): Promise<number> {
     return Number(closest.number);
   } catch (error) {
     console.error("failed query theGraph getBlockByTsGraph");
+    return 0;
+  }
+}
+
+export async function getRelicsFbeetsLocked(
+  block: number,
+  voterAdresses?: string[]
+): Promise<number> {
+  const queryUrl = "https://api.thegraph.com/subgraphs/name/beethovenxfi/reliquary";
+  try {
+    let allResults: RelicBalance[] = [];
+    const first = 1000;
+    let skip = 0;
+    let hasMore = true;
+    while (hasMore) {
+      const query = gql`
+        query fbeetsLocked {
+          users(
+            block: {number: ${block}}
+            where: {address_not_in: ["0x0000000000000000000000000000000000000000"]}
+            first: ${first}
+            skip: ${skip}
+          ) {
+            address
+            relics {
+              relicId
+              balance
+            }
+          }
+        }`;
+      const result = await request(queryUrl, query);
+      allResults = [...allResults, ...result.users];
+      hasMore = result.users.length === first;
+      skip += first;
+    }
+
+    if (!allResults) {
+      return 0;
+    }
+
+    const filteredUsers = !voterAdresses
+      ? allResults
+      : allResults.filter(x => voterAdresses.includes(x.address.toLowerCase()));
+    const userBalances = filteredUsers.map(x => {
+      return {
+        address: x.address,
+        balance: x.relics.reduce((sum, x) => {
+          return sum + parseFloat(x.balance);
+        }, 0),
+      };
+    });
+    const total = userBalances.reduce((sum, x) => sum + x.balance, 0);
+    return total;
+  } catch (error) {
+    console.error("failed query theGraph getRelicsFbeetsLocked");
     return 0;
   }
 }


### PR DESCRIPTION
fixes #112 

new function to retrieve total fBEETS locked in reliquaries:
`getRelicsFbeetsLocked(block: number, voterAddress?: string[]): Promise<number>`

showing total number of fBEETS locked in relics. If you add a list of addresses (list of voters for example), you only get the sum accoring to this list. 

new parameter in chartdata: `pricePerVp: number` holds the average price for one vote. equals to priceFbeets for rounds before 32.
Echart data changed accordingly.
