### PR TITLE
add maBEETS infos to briber's dashboard

### DIFF
--- a/src/components/TopRow.tsx
+++ b/src/components/TopRow.tsx
@@ -143,7 +143,9 @@ export const TopRow = () => {
           <>
             <Box>
               <Text fontSize="0.8rem" fontWeight="bold" color="#ED1200">
-                {accountConnected ? `VP: ${votingPower?.toFixed(0)}` : ""}
+                {accountConnected
+                  ? `VP: ${votingPower?.toLocaleString("en-us", { maximumFractionDigits: 0 })}`
+                  : ""}
               </Text>
             </Box>
             <Box>

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -21,6 +21,7 @@ import { MyGlobalContext } from "contexts/GlobalContext";
 import "@fontsource/inter/400.css";
 import "@fontsource/inter/600.css";
 import "@fontsource/inter/800.css";
+import Head from "next/head";
 
 const queryClient = new QueryClient();
 
@@ -28,7 +29,7 @@ const MyApp = ({
   Component,
   pageProps: { session, ...pageProps },
 }: AppProps<{ session: Session }>) => {
-  const [requestedRound, requestRound] = useState<number|undefined>(undefined);
+  const [requestedRound, requestRound] = useState<number | undefined>(undefined);
   const [display, setDisplay] = useState<string>("cards");
   const [voteActive, setVoteActive] = useState<boolean>(false);
 
@@ -49,6 +50,9 @@ const MyApp = ({
             <RainbowKitProvider chains={chains} modalSize="compact" theme={darkTheme()}>
               <ChakraProvider theme={theme}>
                 <ColorModeScript initialColorMode={theme.config.initialColorMode} />
+                <Head>
+                  <title>Beetswars</title>
+                </Head>
                 <TopRow />
                 <Header />
                 <Component {...pageProps} />

--- a/src/pages/round/[...number].tsx
+++ b/src/pages/round/[...number].tsx
@@ -93,7 +93,7 @@ export default function Round() {
                   key={i}
                   p={5}
                   border="1px"
-                  width="300px"
+                  width="310px"
                   borderRadius={20}
                   backgroundColor={bgCard}
                 >
@@ -127,7 +127,7 @@ export default function Round() {
                       <HStack>
                         <Text>Vote Total:</Text>
                         <Text as="b">
-                          {bribe.percent} % - [{bribe.votes.toLocaleString("en-us")}]
+                          {bribe.percent}% - {bribe.votes.toLocaleString("en-us")}
                         </Text>
                       </HStack>
                       <HStack>

--- a/src/types/bribersDashboard.trpc.ts
+++ b/src/types/bribersDashboard.trpc.ts
@@ -9,6 +9,7 @@ export const DashboardData = z.object({
   totalVoteIncentives: z.number(),
   voteIncentivesRoi: z.number(),
   poolsOverThreshold: z.number(),
+  totalVotingPower: z.number(),
   totalRelics: z.number(),
   payoutStatus: z.enum(["estimated", "payout active", "settled"]),
 });

--- a/src/types/theGraph.raw.ts
+++ b/src/types/theGraph.raw.ts
@@ -1,0 +1,62 @@
+import * as z from "zod";
+
+export const Address = z.string().regex(/^0x[0-9a-fA-F]{40}$/);
+
+export type Address = z.infer<typeof Address>;
+
+export const Blocks = z.object({
+  blocks: z
+    .object({
+      timestamp: z.string(),
+      number: z.string(),
+    })
+    .array(),
+});
+
+export type Blocks = z.infer<typeof Blocks>;
+
+export const RelicBalance = z.object({
+  address: Address,
+  relics: z
+    .object({
+      relicId: z.number(),
+      balance: z.string(),
+    })
+    .array(),
+});
+
+export type RelicBalance = z.infer<typeof RelicBalance>;
+
+export const RelicCount = z.object({
+  reliquaries: z
+    .object({
+      relicCount: z.number(),
+      id: Address,
+      pools: z
+        .object({
+          pid: z.number(),
+          relicCount: z.number(),
+        })
+        .array(),
+    })
+    .array(),
+});
+
+export type RelicCount = z.infer<typeof RelicCount>;
+
+export const RelicPoolLevels = z.object({
+  poolLevels: z
+    .object({
+      allocationPoints: z.number(),
+      balance: z.number(),
+      level: z.number(),
+      pool: z.object({
+        pid: z.number(),
+        relicCount: z.number(),
+        totalBalance: z.number(),
+      }),
+    })
+    .array(),
+});
+
+export type RelicPoolLevels = z.infer<typeof RelicPoolLevels>;

--- a/src/utils/api/bribersDashboard.helper.ts
+++ b/src/utils/api/bribersDashboard.helper.ts
@@ -61,7 +61,7 @@ export async function commonDashData(round = 0): Promise<CardData[]> {
     round >= FIRST_ROUND_FOR_RECLICS
       ? {
           heading: "maBEETS voting power",
-          text: `out of ${totalFbeets.toLocaleString()} fBEETS locked`,
+          text: `out of ${totalFbeets.toLocaleString()} fBEETS deposited`,
           footer: data.totalVotingPower.toLocaleString(undefined, { maximumFractionDigits: 0 }),
         }
       : {

--- a/src/utils/api/bribersDashboard.helper.ts
+++ b/src/utils/api/bribersDashboard.helper.ts
@@ -5,13 +5,15 @@ import { readOneBribefile } from "utils/database/bribefile.db";
 import { findConfigEntry } from "utils/database/config.db";
 import { readRoundPoolentries } from "utils/database/votablePools.db";
 import { getTotalFbeets } from "utils/externalData/liveRpcQueries";
-import { getSnapshotVotesPerPool } from "utils/externalData/snapshot";
-import { getBlockByTsGraph } from "utils/externalData/theGraph";
+import { getSnapshotProposal, getSnapshotVotesPerPool } from "utils/externalData/snapshot";
+import { getBlockByTsGraph, getRelicLevelInfo } from "utils/externalData/theGraph";
 import { getEmissionForRound } from "./bribeApr.helper";
 import getBribeData, { getBribeDataCalculated } from "./bribedata.helper";
 import { getEmissionForBlockspan } from "./emission.helper";
 import { getRoundlistNum } from "./roundlist.helper";
 import { initialInsertFromSnapshot } from "./votablePools.helper";
+
+const FIRST_ROUND_FOR_RECLICS = 32;
 
 export async function roundlist() {
   const result = await getRoundlistNum(true);
@@ -22,6 +24,7 @@ export async function commonDashData(round = 0): Promise<CardData[]> {
   if (!round) return [];
   const data = await dashData(round);
   const roundtext = `for Round ${round} ${data.payoutStatus !== "settled" ? "(estimated)" : ""}`;
+  const totalFbeets = Math.round(data.totalFbeetsSupply);
   if (!data) return [];
   return [
     {
@@ -55,13 +58,24 @@ export async function commonDashData(round = 0): Promise<CardData[]> {
       text: `for Round ${round}`,
       footer: "$ " + data.totalVoteIncentives.toLocaleString(),
     },
-    {
-      heading: "Total fBEETS Supply",
-      text: "totally minted fBEETS",
-      footer: data.totalFbeetsSupply.toLocaleString(),
-    },
-    // { heading: "Total Relics", text: "up to now", footer: data.totalRelics.toString() },
-    { heading: "Payout Status", text: "", footer: data.payoutStatus },
+    round >= FIRST_ROUND_FOR_RECLICS
+      ? {
+          heading: "maBEETS voting power",
+          text: `out of ${totalFbeets.toLocaleString()} fBEETS locked`,
+          footer: data.totalVotingPower.toLocaleString(undefined, { maximumFractionDigits: 0 }),
+        }
+      : {
+          heading: "Total voting Power",
+          text: "totally minted fBEETS",
+          footer: totalFbeets.toLocaleString(),
+        },
+    round >= FIRST_ROUND_FOR_RECLICS
+      ? {
+          heading: "Total Relics",
+          text: "at vote snapshot time",
+          footer: data.totalRelics.toString(),
+        }
+      : { heading: "Payout Status", text: "", footer: data.payoutStatus },
   ];
 }
 
@@ -133,7 +147,7 @@ export async function dashData(round = 0): Promise<DashboardData> {
   const poolsOverThreshold = votablePools.reduce((sum, x) => (x.isUncapped ? sum + 1 : sum), 0);
   const beetsEmissionsPerDay = Math.floor(await getEmissionForBlockspan(startBlock, endBlock));
   const fantomBlocksPerDay = endBlock - startBlock;
-  const totalFbeetsSupply = await getTotalFbeets();
+  let totalFbeetsSupply = await getTotalFbeets();
   const roundBeetsEmissions = Math.round(roundEmissions?.voteEmission || 0);
   // divert to live data, if round eq latest
   let totalVoteIncentives = roundEmissions?.totalBribes || 0;
@@ -149,7 +163,24 @@ export async function dashData(round = 0): Promise<DashboardData> {
         : Math.round((bribedEmissions / totalVoteIncentives) * 100);
     }
   }
-
+  //get relics and maxVP
+  let totalRelics = 0;
+  let totalVotingPower = totalFbeetsSupply;
+  if (round >= FIRST_ROUND_FOR_RECLICS) {
+    totalFbeetsSupply = 0;
+    const bribefile = await readOneBribefile(round); // raw data from database
+    if (!!bribefile) {
+      const proposal = bribefile.snapshot;
+      const prop = await getSnapshotProposal(proposal);
+      if (!!prop) {
+        const block = parseInt(prop.snapshot);
+        const levelInfo = await getRelicLevelInfo(block);
+        totalFbeetsSupply = levelInfo?.totalFbeets || 0;
+        totalRelics = levelInfo?.relicCount || 0;
+        totalVotingPower = levelInfo?.totalVotingPower || 0;
+      }
+    }
+  }
   const result: DashboardData = {
     beetsEmissionsPerDay,
     fantomBlocksPerDay,
@@ -159,7 +190,8 @@ export async function dashData(round = 0): Promise<DashboardData> {
     totalVoteIncentives,
     voteIncentivesRoi,
     poolsOverThreshold,
-    totalRelics: 0,
+    totalRelics,
+    totalVotingPower,
     payoutStatus,
   };
   return result;


### PR DESCRIPTION
fixes #120 

Starting with round 32 change briber's dashboard:
- add relics count (at vote snapshot)
- add total maBEETS voting power and totally locked fBEETS (at vote snapshot) 

Add page title to browser tabs (requested by groninge)
