### PR TITLE
Voteend cron fixes

### DIFF
--- a/src/components/AdminNav.tsx
+++ b/src/components/AdminNav.tsx
@@ -7,6 +7,7 @@ export const AdminNav = () => {
   const adminPath = "/admin";
   const bribeformPath = "/bribeform";
   const poolPath = "/editVotablePools";
+  const logPath = "/cronLogs";
 
   return (
     <>
@@ -29,6 +30,12 @@ export const AdminNav = () => {
             isActive={currentPath === poolPath ? true : false}
           >
             Edit votable Pools
+          </Button>
+          <Button
+            onClick={() => router.push(logPath)}
+            isActive={currentPath === logPath ? true : false}
+          >
+            Cron Logs
           </Button>
         </HStack>
       </Card>

--- a/src/pages/api/v1/cron/voteEnd.ts
+++ b/src/pages/api/v1/cron/voteEnd.ts
@@ -9,7 +9,7 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
   const round = Number(latest) || 0;
   const newRound = await getData(round);
   const now = Math.floor(Date.now() / 1000);
-  if (now < newRound.voteEnd) {
+  if (now < newRound.voteEnd || now > newRound.voteEnd + 7 * 24 * 60 * 60) {
     const myvalue = {
       error: "too early, did not write to database",
       value: newRound,

--- a/src/pages/cronLogs.tsx
+++ b/src/pages/cronLogs.tsx
@@ -1,0 +1,73 @@
+import type { NextPage } from "next";
+import { useSession } from "next-auth/react";
+import {
+  Text,
+  Table,
+  Thead,
+  Tr,
+  Th,
+  Tbody,
+  Td,
+  Card,
+  HStack,
+  VStack,
+  Progress,
+} from "@chakra-ui/react";
+import { trpc } from "utils/trpc";
+import { useEffect } from "react";
+import Router from "next/router";
+import AdminNav from "components/AdminNav";
+
+const CronLogs: NextPage = () => {
+  const { data: session, status } = useSession();
+  useEffect(() => {
+    if (!session) Router.push("/admin");
+  });
+
+  const cronlogs = trpc.cronlogs.list.useQuery(undefined, { enabled: !!session }).data?.entries;
+
+  if (session && status === "authenticated") {
+    if (!cronlogs)
+      return (
+        <>
+          <AdminNav />
+          <Progress size="xs" isIndeterminate />
+        </>
+      );
+    return (
+      <VStack maxW={800} mx="auto" align="center" justifyContent="center">
+        <AdminNav />
+        <Card m={6} p={6}>
+          <Table variant="striped" colorScheme="teal" size="sm">
+            <Thead>
+              <Tr>
+                <Th>Job Name</Th>
+                <Th>Date-Time</Th>
+                <Th>Timestamp</Th>
+              </Tr>
+            </Thead>
+            <Tbody>
+              {cronlogs &&
+                cronlogs.map((entry, index) => (
+                  <Tr key={index}>
+                    <Td>{entry.jobName}</Td>
+                    <Td>{entry.dateReadable}</Td>
+                    <Td>{entry.timestamp}</Td>
+                  </Tr>
+                ))}
+            </Tbody>
+          </Table>
+        </Card>
+      </VStack>
+    );
+  }
+  return (
+    <VStack>
+      <HStack>
+        <Text>Not signed in</Text>
+      </HStack>
+    </VStack>
+  );
+};
+
+export default CronLogs;

--- a/src/server/trpc/router/_app.ts
+++ b/src/server/trpc/router/_app.ts
@@ -3,6 +3,7 @@ import { bribedataRouter } from "./bribedata";
 import { dashboardRouter } from "./bribersDashboard";
 import { bribesRouter } from "./bribes";
 import { chartdataRouter } from "./chartdata";
+import { cronlogRouter } from "./cronlog";
 import { exampleRouter } from "./example";
 import { loginRouter } from "./loginId";
 import { statsRouter } from "./overallStats";
@@ -19,6 +20,7 @@ export const appRouter = router({
   bribes: bribedataRouter,
   votepools: votepoolsRouter,
   dashboard: dashboardRouter,
+  cronlogs: cronlogRouter,
 });
 
 // export type definition of API

--- a/src/server/trpc/router/cronlog.ts
+++ b/src/server/trpc/router/cronlog.ts
@@ -1,0 +1,10 @@
+import { readAllCronLogs } from "utils/database/cronLog.db";
+import { router, publicProcedure } from "../trpc";
+
+export const cronlogRouter = router({
+  list: publicProcedure.query(async () => {
+    return {
+      entries: await readAllCronLogs(),
+    };
+  }),
+});

--- a/src/utils/externalData/beetsBack.ts
+++ b/src/utils/externalData/beetsBack.ts
@@ -1,5 +1,6 @@
 import { request, gql } from "graphql-request";
 
+// get historic price for single token
 export async function getTokenPrice(timestamp: number, address: string): Promise<number> {
   type Chartdata = { id: string; price: string; timestamp: number };
   const queryUrl = "https://backend-v2.beets-ftm-node.com/graphql";
@@ -29,6 +30,75 @@ export async function getTokenPrice(timestamp: number, address: string): Promise
       { id: "", price: "", timestamp: 0 }
     );
     return +result.price;
+  } catch (error) {
+    console.error("Beetswars backend: ", error);
+    return 0;
+  }
+}
+
+// get historic price for BPT pool
+export async function getPoolPriceHist(timestamp: number, address: string): Promise<number> {
+  type PoolChartdata = { sharePrice: string; timestamp: number };
+  const queryUrl = "https://backend-v2.beets-ftm-node.com/graphql";
+  const query = gql`
+    query PoolData {
+      poolGetSnapshots(
+        id: "${address}"
+        range: THIRTY_DAYS
+      ) {
+        sharePrice
+        timestamp
+      }
+    }
+  `;
+  try {
+    const { poolGetSnapshots } = (await request(queryUrl, query)) as {
+      poolGetSnapshots: PoolChartdata[];
+    };
+    const result = poolGetSnapshots.reduce(
+      (max, current) => {
+        if (Number(current.timestamp) <= timestamp && Number(current.timestamp) > max.timestamp) {
+          return current;
+        }
+        return max;
+      },
+      { sharePrice: "", timestamp: 0 }
+    );
+    return +result.sharePrice;
+  } catch (error) {
+    console.error("Beetswars backend: ", error);
+    return 0;
+  }
+}
+
+// get current price for BPT pool
+export async function getPoolPriceLive(address: string): Promise<number> {
+  type PoolData = {
+    dynamicData: {
+      totalLiquidity: string;
+      totalShares: number;
+    };
+  };
+  const queryUrl = "https://backend-v2.beets-ftm-node.com/graphql";
+  const query = gql`
+    query PoolData {
+      poolGetPool(
+        id: "${address}"
+      ) {
+        dynamicData{
+          totalLiquidity
+          totalShares
+        }
+      }
+    }
+  `;
+  try {
+    const { poolGetPool } = (await request(queryUrl, query)) as {
+      poolGetPool: PoolData;
+    };
+    const result =
+      Number(poolGetPool.dynamicData.totalLiquidity) / Number(poolGetPool.dynamicData.totalShares);
+    return result;
   } catch (error) {
     console.error("Beetswars backend: ", error);
     return 0;

--- a/src/utils/externalData/pricefeed.ts
+++ b/src/utils/externalData/pricefeed.ts
@@ -1,5 +1,5 @@
 import type { Tokendata } from "types/bribedata.raw";
-import { getTokenPrice } from "./beetsBack";
+import { getPoolPriceHist, getPoolPriceLive, getTokenPrice } from "./beetsBack";
 import { getCoingeckoCurrentPrice, getCoingeckoPrice } from "./coingecko";
 import { getRpcPrice } from "./liveRpcQueries";
 
@@ -12,16 +12,19 @@ export async function getPrice(
     if (!timestamp) return 0;
     if (token.lastprice) return token.lastprice;
     if (token.coingeckoid) {
-      const price = getCoingeckoPrice(token.coingeckoid, timestamp);
+      const price = await getCoingeckoPrice(token.coingeckoid, timestamp);
       if (price) return price;
     }
-    if (token.tokenaddress) return getTokenPrice(timestamp, token.tokenaddress);
+    if (token.isbpt && token.tokenaddress)
+      return await getPoolPriceHist(timestamp, token.tokenaddress);
+    if (token.tokenaddress) return await getTokenPrice(timestamp, token.tokenaddress);
     return 0;
   }
+  if (token.isbpt && token.tokenaddress) return await getPoolPriceLive(token.tokenaddress);
   if (token.tokenaddress) {
-    const price = getRpcPrice(token.tokenaddress);
+    const price = await getRpcPrice(token.tokenaddress);
     if (price) return price;
   }
-  if (token.coingeckoid) return getCoingeckoCurrentPrice(token.coingeckoid);
+  if (token.coingeckoid) return await getCoingeckoCurrentPrice(token.coingeckoid);
   return 0;
 }

--- a/vercel.json
+++ b/vercel.json
@@ -3,6 +3,10 @@
     {
       "path": "/api/v1/cron/updateEmissionChange",
       "schedule": "30 6 * * *"
+    },
+    {
+      "path": "/api/v1/cron/voteEnd",
+      "schedule": "5,10,15,25 16 * * 0"
     }
   ]
 }


### PR DESCRIPTION
fix many issues with voteEnd cronjob
- add voteEnd to vercel cron
- add beethovenX backen pricefeed for BPTs current and historic price
- fix pricefeed errors (multiple missing await)
- add new fBEETS price call to voteEnd (diverted by round no)
- store any valid tokenprices found to lastprice (reduces future api calls)
- exclude voteEnd run on non-voting weekends
- add a page to display cron logs, add a button to admin menu

fixes #124 
fixes #125 
fixes #126 
fixes #127 