### PR TITLE
fix split with amount = 0

### DIFF
--- a/src/hooks/useSplitRelic.ts
+++ b/src/hooks/useSplitRelic.ts
@@ -36,7 +36,7 @@ export function useSplitRelic(toAddress: string, relicId: string, amount: BigNum
     abi: ReliquaryAbi,
     functionName: "split",
     args: [Number(relicId), amount, toAddress],
-    enabled: Number(relicId) > 0 && !!toAddress && !amount.eq(0),
+    enabled: Number(relicId) > 0 && !!toAddress && amount.eq(0),
   });
 
   const { write, isError, data } = useContractWrite({


### PR DESCRIPTION
user was able to split a relic with the amount equal to 0. fixed