### PR TITLE
fix 3 errors on voteend cronjobs

### DIFF
--- a/src/components/EditToken/EditToken.tsx
+++ b/src/components/EditToken/EditToken.tsx
@@ -56,10 +56,10 @@ export function EditTokenModal(props: modalProps) {
   const openModal = () => {
     if (data) {
       console.log("set token values");
-      setTokenaddress(data.tokenaddress);
-      setCoingeckoid(data.coingeckoid);
-      setBptpoolid(data.bptpoolid);
-      setIsbpt(data.isbpt);
+      setTokenaddress(data.tokenaddress || undefined);
+      setCoingeckoid(data.coingeckoid || undefined);
+      setBptpoolid(data.bptpoolid || undefined);
+      setIsbpt(data.isbpt || undefined);
       setLastprice((data.lastprice || "").toString());
       setToken(data.token);
       setTokenId(data.tokenId);
@@ -75,10 +75,10 @@ export function EditTokenModal(props: modalProps) {
     if (!newtoken || newtoken.token === "") return;
     console.log("newtoken: ", newtoken.token);
     setToken(newtoken.token);
-    setTokenaddress(newtoken.tokenaddress);
-    setCoingeckoid(newtoken.coingeckoid);
-    setBptpoolid(newtoken.bptpoolid);
-    setIsbpt(newtoken.isbpt);
+    setTokenaddress(newtoken.tokenaddress || undefined);
+    setCoingeckoid(newtoken.coingeckoid || undefined);
+    setBptpoolid(newtoken.bptpoolid || undefined);
+    setIsbpt(newtoken.isbpt || undefined);
     setTokenId(0);
   };
 

--- a/src/types/bribedata.raw.ts
+++ b/src/types/bribedata.raw.ts
@@ -2,11 +2,11 @@ import * as z from "zod";
 
 export const Tokendata = z.object({
   token: z.string(),
-  tokenaddress: z.string().optional(),
-  coingeckoid: z.string().optional(),
-  bptpoolid: z.string().optional(),
-  isbpt: z.boolean().optional(),
-  lastprice: z.number().optional(),
+  tokenaddress: z.string().nullable().optional(),
+  coingeckoid: z.string().nullable().optional(),
+  bptpoolid: z.string().nullable().optional(),
+  isbpt: z.boolean().nullable().optional(),
+  lastprice: z.number().nullable().optional(),
   tokenId: z.number(),
 });
 export type Tokendata = z.infer<typeof Tokendata>;

--- a/src/utils/api/cron.helper.ts
+++ b/src/utils/api/cron.helper.ts
@@ -98,7 +98,7 @@ export async function getData(round: number) {
     for (const reward of bribe.reward) {
       let amount = reward.amount;
       if (!reward.isfixed) {
-        if ((reward.token = "BEETS")) {
+        if (reward.token === "BEETS") {
           amount *= priceBeets;
         } else {
           const rewardtoken = bribefile.tokendata.find(x => x.token === reward.token);

--- a/src/utils/externalData/beetsBack.ts
+++ b/src/utils/externalData/beetsBack.ts
@@ -7,7 +7,7 @@ export async function getTokenPrice(timestamp: number, address: string): Promise
   const query = gql`
     query Chartdata {
       tokenGetPriceChartData(
-        address: "${address}"
+        address: "${address.toLowerCase()}"
         range: THIRTY_DAY
       ) {
         id


### PR DESCRIPTION
fixes #133 

eliminate errors on voteend cronjob:
- fix if statement in cron.helper.ts
- change type definition for Tokendata: allow `null` values
- convert Address to lowercase in beethoven-x backend query

Also tweaked EditToken Component to deal with typedef changes