### PR TITLE
Auto add round feature

### DIFF
--- a/src/pages/api/v1/cron/snapshot.ts
+++ b/src/pages/api/v1/cron/snapshot.ts
@@ -1,0 +1,9 @@
+import type { NextApiRequest, NextApiResponse } from "next";
+import { addRoundFromSnapshot } from "utils/api/round.helper";
+
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+  if (req.method !== "GET") return res.status(501).send("not implemented");
+  const data = await addRoundFromSnapshot();
+  if (!data) return res.status(400).send("No new round entry found");
+  res.send(JSON.stringify(data, null, "  "));
+}

--- a/src/types/snapshot.raw.ts
+++ b/src/types/snapshot.raw.ts
@@ -32,3 +32,10 @@ export interface SnapProposal {
   choices: string[]; // list of pools
   strategies: SpaceStrategy[]; // JSON object of all strategies
 }
+
+export interface RoundProposal {
+  id: string;
+  title: string;
+  start: number;
+  snapshot: string;
+}

--- a/src/utils/api/round.helper.ts
+++ b/src/utils/api/round.helper.ts
@@ -1,0 +1,45 @@
+import { getSnapshotLatestRound } from "utils/externalData/snapshot";
+import { addRound } from "./editBribedata";
+import { findConfigEntry, setConfigEntry } from "utils/database/config.db";
+import type { Bribefile } from "types/bribedata.raw";
+import { initialInsertFromSnapshot } from "./votablePools.helper";
+import type { Config } from "types/config.raw";
+
+export async function addRoundFromSnapshot(): Promise<string | null> {
+  const latest = Number(await findConfigEntry("latest")) || 0; // latest round number in database
+  const latestProposal = await getSnapshotLatestRound(); // latest round proposal on snapshot
+  const match = latestProposal?.title.match(/\(round (\d+)\)/);
+  const round = match ? parseInt(match[1] || "", 10) : 0; // round number
+
+  // check if there is a proposal that is not added to database
+  if (latest && round > latest) { 
+    try {
+      // add round
+      const newRound: Bribefile = {
+        round: round,
+        version: "",
+        description: latestProposal?.title || "",
+        snapshot: latestProposal?.id || "",
+        tokendata: [],
+        bribedata: [],
+      };
+      const newEntry = await addRound(newRound);
+      if (!newEntry) return null;
+
+      // set latest
+      const entry: Config = { name: "latest", data: round };
+      const newLatest = await setConfigEntry(entry);
+      if (!newLatest) return null;
+
+      // initial fill
+      const newInit = await initialInsertFromSnapshot(round, latestProposal?.id);
+      if (!newInit) return null;
+      return "new Round: " + round + " new Snapshot: " + latestProposal?.id;
+    } catch (error) {
+      console.error("Could not add new round: " + error);
+      return null;
+    }
+  } else {
+    return null;
+  }
+}

--- a/src/utils/api/votablePools.helper.ts
+++ b/src/utils/api/votablePools.helper.ts
@@ -26,7 +26,7 @@ export async function initialInsertFromSnapshot(
         poolName: choice,
         voteindex: index,
         round,
-        isUncapped: false,
+        isUncapped: true,
         capMultiplier: 1.0,
       } as VotablePool;
     });

--- a/src/utils/externalData/snapshot.ts
+++ b/src/utils/externalData/snapshot.ts
@@ -1,5 +1,5 @@
 import { request, gql } from "graphql-request";
-import type { SnapProposal, SnapSplitVote, SnapVote, SnapVotePerPool } from "types/snapshot.raw";
+import type { RoundProposal, SnapProposal, SnapSplitVote, SnapVote, SnapVotePerPool } from "types/snapshot.raw";
 
 const queryUrl = "https://hub.snapshot.org/graphql";
 
@@ -94,6 +94,34 @@ export async function getSnapshotProposal(proposal: string): Promise<SnapProposa
     return data.proposal as SnapProposal;
   } catch (error) {
     console.error("failed getSnapshotProposal: ", error);
+    return null;
+  }
+}
+
+export async function getSnapshotLatestRound(): Promise<RoundProposal | null> {
+
+const QUERY = gql`
+  query Proposals {
+    proposals(
+      first: 300
+      skip: 0
+      where: { space_in: ["beets.eth"], title_contains: "Farming Incentive Gauge Vote" }
+      orderBy: "created"
+      orderDirection: desc
+    ) {
+      id
+      title
+      start
+      snapshot
+    }
+  }
+`;
+
+  try {
+    const data = await request(queryUrl, QUERY);
+    return data.proposals[0] as RoundProposal;
+  } catch (error) {
+    console.error("failed getSnapshotLatestRound: ", error);
     return null;
   }
 }

--- a/vercel.json
+++ b/vercel.json
@@ -11,6 +11,10 @@
     {
       "path": "/api/v1/cron/hiddenhand",
       "schedule": "*/10 * * * 4,5,6,0,1"
+    },
+    {
+      "path": "/api/v1/cron/snapshot",
+      "schedule": "*/20 * * * 3,4"
     }
   ]
 }


### PR DESCRIPTION
closes #160 

Auto add new round from snapshot listing
- checks and finds new round, if available
- enters data into database
- sets the "latest" entry
- reads initial proposed pools listing
- adds all pools with "uncapped" entry - I don't know how to automatically find capped pools

Changed cron tab entry: runs new task on wednesdays and thursdays on every hour to catch a new listing, whenever it is entered before new round start.